### PR TITLE
Update and fix linting + formatting.

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,6 +13,7 @@ module.exports = {
     '.eslintrc.cjs',
     'postcss.config.cjs',
     'prettier.config.cjs',
+    'vitest.setup.ts',
   ],
   parser: '@typescript-eslint/parser',
   plugins: ['prettier', 'react-refresh'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "clsx": "^2.1.1",
         "fuse.js": "^7.0.0",
         "luxon": "^3.4.4",
+        "prettier": "^3.3.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-tooltip": "^5.26.4",
@@ -47,7 +48,7 @@
         "eslint-plugin-tailwindcss": "^3.17.0",
         "jsdom": "^24.0.0",
         "postcss": "^8.4.38",
-        "prettier-plugin-tailwindcss": "^0.5.14",
+        "prettier-plugin-tailwindcss": "^0.6.1",
         "tailwindcss": "^3.4.3",
         "typescript": "^5.4.5",
         "vite": "^5.2.11"
@@ -5977,10 +5978,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
-      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
-      "dev": true,
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.0.tgz",
+      "integrity": "sha512-J9odKxERhCQ10OC2yb93583f6UnYutOeiV5i0zEDS7UGTdUt0u+y8erxl3lBKvwo/JHyyoEdXjwp4dke9oyZ/g==",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6004,9 +6004,9 @@
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.14.tgz",
-      "integrity": "sha512-Puaz+wPUAhFp8Lo9HuciYKM2Y2XExESjeT+9NQoVFXZsPPnc9VYss2SpxdQ6vbatmt8/4+SN0oe0I1cPDABg9Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.1.tgz",
+      "integrity": "sha512-AnbeYZu0WGj+QgKciUgdMnRxrqcxltleZPgdwfA5104BHM3siBLONN/HLW1yS2HvzSNkzpQ/JAj+LN0jcJO+0w==",
       "dev": true,
       "engines": {
         "node": ">=14.21.3"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "clsx": "^2.1.1",
     "fuse.js": "^7.0.0",
     "luxon": "^3.4.4",
+    "prettier": "^3.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-tooltip": "^5.26.4",
@@ -53,7 +54,7 @@
     "eslint-plugin-tailwindcss": "^3.17.0",
     "jsdom": "^24.0.0",
     "postcss": "^8.4.38",
-    "prettier-plugin-tailwindcss": "^0.5.14",
+    "prettier-plugin-tailwindcss": "^0.6.1",
     "tailwindcss": "^3.4.3",
     "typescript": "^5.4.5",
     "vite": "^5.2.11"

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -57,7 +57,7 @@ const Slider: React.FC<SliderProps> = ({
       >
         <Track
           className={cn(
-            'relative h-2 w-full grow overflow-hidden rounded-full bg-primary-300 group-hover:bg-primary-400 ',
+            'relative h-2 w-full grow overflow-hidden rounded-full bg-primary-300 group-hover:bg-primary-400',
             disabled && '!bg-gray-300',
           )}
         >

--- a/src/routes/gallery/_layout/input.tsx
+++ b/src/routes/gallery/_layout/input.tsx
@@ -1,5 +1,5 @@
-import { createFileRoute } from '@tanstack/react-router'
-import GalleryInput from '@/components/Input/GalleryInput'
+import { createFileRoute } from '@tanstack/react-router';
+import GalleryInput from '@/components/Input/GalleryInput';
 
 export const Route = createFileRoute('/gallery/_layout/input')({
   component: GalleryInput,


### PR DESCRIPTION
* update `prettier-plugin-tailwindcss` to version `0.6.1`. now Formats whitespace and removes duplicates in tailwind classes.
* add `'vitest.setup.ts'` to eslintrc ignore pattern.
* add prettier as dependency in package.json
* fix formating in some files.